### PR TITLE
✨ Cloudflareプロバイダー用の環境変数をTerraformアクションに追加

### DIFF
--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -35,6 +35,8 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       env:
+        # Cloudflare provider 用の環境変数
+        CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
         # domain ディレクトリで使用される変数を TF_VAR_ で渡す
         TF_VAR_gcp_project_id: ${{ env.GCP_PROJECT_ID }}
         TF_VAR_cloudflare_api_token: ${{ env.CLOUDFLARE_API_TOKEN }}

--- a/.github/actions/terraform-plan/action.yml
+++ b/.github/actions/terraform-plan/action.yml
@@ -82,6 +82,8 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       env:
+        # Cloudflare provider 用の環境変数
+        CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
         # domain ディレクトリで使用される変数を TF_VAR_ で渡す
         TF_VAR_gcp_project_id: ${{ env.GCP_PROJECT_ID }}
         TF_VAR_cloudflare_api_token: ${{ env.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION

このプルリクエストでは、Cloudflareプロバイダー用の環境変数 `CLOUDFLARE_API_TOKEN` をTerraformアクションに追加しました。これにより、Terraformの実行時にCloudflareのAPIトークンを利用できるようになります。

## 📒 変更の概要

- `action.yml` ファイルに `CLOUDFLARE_API_TOKEN` 環境変数を追加しました。
  - `terraform-apply/action.yml`
  - `terraform-plan/action.yml`

## ⚒ 技術的詳細

- `CLOUDFLARE_API_TOKEN` 環境変数は、Cloudflareプロバイダーを使用するために必要です。
- これにより、Terraformの `TF_VAR_cloudflare_api_token` 変数にAPIトークンを渡すことができます。

## ⚠ 注意点

- 💡 環境変数 `CLOUDFLARE_API_TOKEN` が正しく設定されていることを確認してください。設定されていない場合、Terraformの実行が失敗する可能性があります。