### PR TITLE
✨ TerraformアクションにCloudflare関連の環境変数を追加

### DIFF
--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -31,22 +31,20 @@ runs:
       shell: bash
 
     - name: Terraform Apply
-      run: terraform apply -auto-approve
+      run: |
+        export CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN}"
+        export TF_VAR_gcp_project_id="${GCP_PROJECT_ID}"
+        export TF_VAR_cloudflare_api_token="${CLOUDFLARE_API_TOKEN}"
+        export TF_VAR_cloudflare_account_id="${CLOUDFLARE_ACCOUNT_ID}"
+        export TF_VAR_contact_country_code="${CONTACT_COUNTRY_CODE}"
+        export TF_VAR_contact_postal_code="${CONTACT_POSTAL_CODE}"
+        export TF_VAR_contact_administrative_area="${CONTACT_ADMINISTRATIVE_AREA}"
+        export TF_VAR_contact_locality="${CONTACT_LOCALITY}"
+        export TF_VAR_contact_recipient="${CONTACT_RECIPIENT}"
+        export TF_VAR_contact_email="${CONTACT_EMAIL}"
+        export TF_VAR_contact_phone="${CONTACT_PHONE}"
+        export TF_VAR_yearly_price_currency="${YEARLY_PRICE_CURRENCY}"
+        export TF_VAR_yearly_price_units="${YEARLY_PRICE_UNITS}"
+        terraform apply -auto-approve
       working-directory: ${{ inputs.working-directory }}
       shell: bash
-      env:
-        # Cloudflare provider 用の環境変数
-        CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
-        # domain ディレクトリで使用される変数を TF_VAR_ で渡す
-        TF_VAR_gcp_project_id: ${{ env.GCP_PROJECT_ID }}
-        TF_VAR_cloudflare_api_token: ${{ env.CLOUDFLARE_API_TOKEN }}
-        TF_VAR_cloudflare_account_id: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
-        TF_VAR_contact_country_code: ${{ env.CONTACT_COUNTRY_CODE }}
-        TF_VAR_contact_postal_code: ${{ env.CONTACT_POSTAL_CODE }}
-        TF_VAR_contact_administrative_area: ${{ env.CONTACT_ADMINISTRATIVE_AREA }}
-        TF_VAR_contact_locality: ${{ env.CONTACT_LOCALITY }}
-        TF_VAR_contact_recipient: ${{ env.CONTACT_RECIPIENT }}
-        TF_VAR_contact_email: ${{ env.CONTACT_EMAIL }}
-        TF_VAR_contact_phone: ${{ env.CONTACT_PHONE }}
-        TF_VAR_yearly_price_currency: ${{ env.YEARLY_PRICE_CURRENCY }}
-        TF_VAR_yearly_price_units: ${{ env.YEARLY_PRICE_UNITS }}

--- a/.github/actions/terraform-plan/action.yml
+++ b/.github/actions/terraform-plan/action.yml
@@ -78,25 +78,22 @@ runs:
       id: terraform-plan
       run: |
         # デバッグログをリアルタイムで標準エラー出力に流しながら、plan結果はファイルに保存
+        export CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN}"
+        export TF_VAR_gcp_project_id="${GCP_PROJECT_ID}"
+        export TF_VAR_cloudflare_api_token="${CLOUDFLARE_API_TOKEN}"
+        export TF_VAR_cloudflare_account_id="${CLOUDFLARE_ACCOUNT_ID}"
+        export TF_VAR_contact_country_code="${CONTACT_COUNTRY_CODE}"
+        export TF_VAR_contact_postal_code="${CONTACT_POSTAL_CODE}"
+        export TF_VAR_contact_administrative_area="${CONTACT_ADMINISTRATIVE_AREA}"
+        export TF_VAR_contact_locality="${CONTACT_LOCALITY}"
+        export TF_VAR_contact_recipient="${CONTACT_RECIPIENT}"
+        export TF_VAR_contact_email="${CONTACT_EMAIL}"
+        export TF_VAR_contact_phone="${CONTACT_PHONE}"
+        export TF_VAR_yearly_price_currency="${YEARLY_PRICE_CURRENCY}"
+        export TF_VAR_yearly_price_units="${YEARLY_PRICE_UNITS}"
         TF_LOG=DEBUG terraform plan -detailed-exitcode -no-color 2>&1 | tee tf_plan.txt
       working-directory: ${{ inputs.working-directory }}
       shell: bash
-      env:
-        # Cloudflare provider 用の環境変数
-        CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
-        # domain ディレクトリで使用される変数を TF_VAR_ で渡す
-        TF_VAR_gcp_project_id: ${{ env.GCP_PROJECT_ID }}
-        TF_VAR_cloudflare_api_token: ${{ env.CLOUDFLARE_API_TOKEN }}
-        TF_VAR_cloudflare_account_id: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
-        TF_VAR_contact_country_code: ${{ env.CONTACT_COUNTRY_CODE }}
-        TF_VAR_contact_postal_code: ${{ env.CONTACT_POSTAL_CODE }}
-        TF_VAR_contact_administrative_area: ${{ env.CONTACT_ADMINISTRATIVE_AREA }}
-        TF_VAR_contact_locality: ${{ env.CONTACT_LOCALITY }}
-        TF_VAR_contact_recipient: ${{ env.CONTACT_RECIPIENT }}
-        TF_VAR_contact_email: ${{ env.CONTACT_EMAIL }}
-        TF_VAR_contact_phone: ${{ env.CONTACT_PHONE }}
-        TF_VAR_yearly_price_currency: ${{ env.YEARLY_PRICE_CURRENCY }}
-        TF_VAR_yearly_price_units: ${{ env.YEARLY_PRICE_UNITS }}
 
     - name: tfcmt
       if: steps.terraform-plan.outputs.exitcode != '1'


### PR DESCRIPTION

## 📒 変更の概要

- `terraform-apply` と `terraform-plan` アクションにCloudflare関連の環境変数を追加しました。これにより、Terraformの実行時に必要な情報を環境変数として設定できるようになります。

## ⚒ 技術的詳細

- `terraform-apply` アクションの実行コマンドを変更し、環境変数をエクスポートするようにしました。これにより、以下の変数が設定されます：
  - `CLOUDFLARE_API_TOKEN`
  - `TF_VAR_gcp_project_id`
  - `TF_VAR_cloudflare_api_token`
  - `TF_VAR_cloudflare_account_id`
  - `TF_VAR_contact_country_code`
  - `TF_VAR_contact_postal_code`
  - `TF_VAR_contact_administrative_area`
  - `TF_VAR_contact_locality`
  - `TF_VAR_contact_recipient`
  - `TF_VAR_contact_email`
  - `TF_VAR_contact_phone`
  - `TF_VAR_yearly_price_currency`
  - `TF_VAR_yearly_price_units`

- 同様に、`terraform-plan` アクションでも同じ環境変数をエクスポートするように変更しました。

## ⚠ 注意点

- 💡 環境変数の設定が正しく行われていることを確認してください。特に、CloudflareのAPIトークンやプロジェクトIDなどの機密情報が正確であることが重要です。