### PR TITLE
🌟 既存のCloudflareリソースをインポートする機能を追加

### DIFF
--- a/infra/terraform/envs/dev/databases/README.md
+++ b/infra/terraform/envs/dev/databases/README.md
@@ -22,7 +22,20 @@ turnstile_allowed_domains    = []    # 必要に応じてドメインを追加
 turnstile_widget_mode        = "managed"
 turnstile_bot_fight_mode     = false
 turnstile_region             = "world"
+existing_d1_database_id      = null  # 既存リソースを取り込む場合は ID を設定
+existing_kv_namespace_ids    = {}    # { free_trial = "<namespace_id>" など }
+existing_turnstile_widget_id = null  # 既存 Turnstile を取り込む場合に設定
 ```
+
+## 既存リソースの取り込み
+
+Cloudflare 上に同名のリソースが既に存在する場合は、上記の `existing_*` 変数に ID を設定すると、`terraform apply` 実行時に import ブロックを通じて自動的に状態へ取り込まれます。
+
+- D1 データベース: `existing_d1_database_id = "<account_id>/<database_id>"`
+- Workers KV: `existing_kv_namespace_ids = { free_trial = "<account_id>/<namespace_id>", ... }`
+- Turnstile: `existing_turnstile_widget_id = "<account_id>/<widget_id>"`
+
+ID は `terraform state` や Cloudflare ダッシュボード／API から確認してください。値を設定しない場合は通常通り新規作成されます。
 
 ## 実行
 

--- a/infra/terraform/envs/dev/databases/import.tf
+++ b/infra/terraform/envs/dev/databases/import.tf
@@ -1,0 +1,25 @@
+locals {
+  d1_import_map = var.existing_d1_database_id == null ? {} : { existing = var.existing_d1_database_id }
+  # existing_kv_namespace_ids のキーは modules/cf-app-resources 内の local.kv_namespaces のキー（free_trial など）と一致させる
+  turnstile_import_map = (
+    var.existing_turnstile_widget_id != null && length(var.turnstile_allowed_domains) > 0
+  ) ? { existing = var.existing_turnstile_widget_id } : {}
+}
+
+import {
+  for_each = local.d1_import_map
+  to       = module.cf_app_resources.cloudflare_d1_database.app
+  id       = each.value
+}
+
+import {
+  for_each = var.existing_kv_namespace_ids
+  to       = module.cf_app_resources.cloudflare_workers_kv_namespace.kv[each.key]
+  id       = each.value
+}
+
+import {
+  for_each = local.turnstile_import_map
+  to       = module.cf_app_resources.cloudflare_turnstile_widget.auth[0]
+  id       = each.value
+}

--- a/infra/terraform/envs/dev/databases/variables.tf
+++ b/infra/terraform/envs/dev/databases/variables.tf
@@ -39,3 +39,21 @@ variable "turnstile_region" {
   type        = string
   default     = "world"
 }
+
+variable "existing_d1_database_id" {
+  description = "既存の D1 データベースを取り込む場合の ID"
+  type        = string
+  default     = null
+}
+
+variable "existing_kv_namespace_ids" {
+  description = "既存の Workers KV Namespace を取り込む場合の ID マップ"
+  type        = map(string)
+  default     = {}
+}
+
+variable "existing_turnstile_widget_id" {
+  description = "既存の Turnstile ウィジェットを取り込む場合の ID"
+  type        = string
+  default     = null
+}

--- a/infra/terraform/envs/prod/databases/README.md
+++ b/infra/terraform/envs/prod/databases/README.md
@@ -25,7 +25,20 @@ turnstile_allowed_domains    = [
 turnstile_widget_mode        = "managed"
 turnstile_bot_fight_mode     = false
 turnstile_region             = "world"
+existing_d1_database_id      = null  # 既存リソースを取り込む場合は ID を設定
+existing_kv_namespace_ids    = {}    # { free_trial = "<namespace_id>" など }
+existing_turnstile_widget_id = null  # 既存 Turnstile を取り込む場合に設定
 ```
+
+## 既存リソースの取り込み
+
+Cloudflare 上に同名のリソースが既に存在する場合は、上記の `existing_*` 変数に ID を設定すると、`terraform apply` 実行時に import ブロックを通じて自動的に状態へ取り込まれます。
+
+- D1 データベース: `existing_d1_database_id = "<account_id>/<database_id>"`
+- Workers KV: `existing_kv_namespace_ids = { free_trial = "<account_id>/<namespace_id>", ... }`
+- Turnstile: `existing_turnstile_widget_id = "<account_id>/<widget_id>"`
+
+ID は `terraform state` や Cloudflare ダッシュボード／API から確認してください。値を設定しない場合は通常通り新規作成されます。
 
 ## 実行
 

--- a/infra/terraform/envs/prod/databases/import.tf
+++ b/infra/terraform/envs/prod/databases/import.tf
@@ -1,0 +1,25 @@
+locals {
+  d1_import_map = var.existing_d1_database_id == null ? {} : { existing = var.existing_d1_database_id }
+  # existing_kv_namespace_ids のキーは modules/cf-app-resources 内の local.kv_namespaces のキー（free_trial など）と一致させる
+  turnstile_import_map = (
+    var.existing_turnstile_widget_id != null && length(var.turnstile_allowed_domains) > 0
+  ) ? { existing = var.existing_turnstile_widget_id } : {}
+}
+
+import {
+  for_each = local.d1_import_map
+  to       = module.cf_app_resources.cloudflare_d1_database.app
+  id       = each.value
+}
+
+import {
+  for_each = var.existing_kv_namespace_ids
+  to       = module.cf_app_resources.cloudflare_workers_kv_namespace.kv[each.key]
+  id       = each.value
+}
+
+import {
+  for_each = local.turnstile_import_map
+  to       = module.cf_app_resources.cloudflare_turnstile_widget.auth[0]
+  id       = each.value
+}

--- a/infra/terraform/envs/prod/databases/variables.tf
+++ b/infra/terraform/envs/prod/databases/variables.tf
@@ -42,3 +42,21 @@ variable "turnstile_region" {
   type        = string
   default     = "world"
 }
+
+variable "existing_d1_database_id" {
+  description = "既存の D1 データベースを取り込む場合の ID"
+  type        = string
+  default     = null
+}
+
+variable "existing_kv_namespace_ids" {
+  description = "既存の Workers KV Namespace を取り込む場合の ID マップ"
+  type        = map(string)
+  default     = {}
+}
+
+variable "existing_turnstile_widget_id" {
+  description = "既存の Turnstile ウィジェットを取り込む場合の ID"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION

## 📒 変更の概要

- `README.md`ファイルに、既存のCloudflareリソースを取り込むための変数を追加しました。
- 新しい`import.tf`ファイルを作成し、既存のD1データベース、Workers KV、Turnstileウィジェットをインポートするための設定を追加しました。
- `variables.tf`ファイルに、既存リソースを取り込むための変数を定義しました。

## ⚒ 技術的詳細

- `README.md`ファイルに以下の変数を追加しました:
  - `existing_d1_database_id`: 既存のD1データベースを取り込む場合のID。
  - `existing_kv_namespace_ids`: 既存のWorkers KV Namespaceを取り込む場合のIDマップ。
  - `existing_turnstile_widget_id`: 既存のTurnstileウィジェットを取り込む場合のID。

- 新しい`import.tf`ファイルでは、以下のようにインポートブロックを設定しました:
  - D1データベースのインポート。
  - Workers KV Namespaceのインポート。
  - Turnstileウィジェットのインポート。

```mermaid
graph TD;
    A[Cloudflareリソース] -->|IDを設定| B[Terraform apply];
    B --> C{リソースの種類};
    C -->|D1データベース| D[D1データベースをインポート];
    C -->|Workers KV| E[Workers KVをインポート];
    C -->|Turnstile| F[Turnstileウィジェットをインポート];
```

## ⚠ 注意点

- 既存リソースを取り込む場合は、必ず正しいIDを設定してください。設定しない場合は新規作成されます。
- IDは`terraform state`やCloudflareダッシュボード/APIから確認できます。