### PR TITLE
🚀 Terraformの差分検出スクリプトの修正と既存リソースの取り込み機能の追加

### DIFF
--- a/infra/terraform/envs/dev/databases/README.md
+++ b/infra/terraform/envs/dev/databases/README.md
@@ -22,7 +22,20 @@ turnstile_allowed_domains    = []    # 必要に応じてドメインを追加
 turnstile_widget_mode        = "managed"
 turnstile_bot_fight_mode     = false
 turnstile_region             = "world"
+existing_d1_database_id      = null  # 既存リソースを取り込む場合は ID を設定
+existing_kv_namespace_ids    = {}    # { free_trial = "<namespace_id>" など }
+existing_turnstile_widget_id = null  # 既存 Turnstile を取り込む場合に設定
 ```
+
+## 既存リソースの取り込み
+
+Cloudflare 上に同名のリソースが既に存在する場合は、上記の `existing_*` 変数に ID を設定すると、`terraform apply` 実行時に import ブロックを通じて自動的に状態へ取り込まれます。
+
+- D1 データベース: `existing_d1_database_id = "<account_id>/<database_id>"`
+- Workers KV: `existing_kv_namespace_ids = { free_trial = "<account_id>/<namespace_id>", ... }`
+- Turnstile: `existing_turnstile_widget_id = "<account_id>/<widget_id>"`
+
+ID は `terraform state` や Cloudflare ダッシュボード／API から確認してください。値を設定しない場合は通常通り新規作成されます。
 
 ## 実行
 

--- a/infra/terraform/envs/dev/databases/import.tf
+++ b/infra/terraform/envs/dev/databases/import.tf
@@ -1,0 +1,25 @@
+locals {
+  d1_import_map = var.existing_d1_database_id == null ? {} : { existing = var.existing_d1_database_id }
+  # existing_kv_namespace_ids のキーは modules/cf-app-resources 内の local.kv_namespaces のキー（free_trial など）と一致させる
+  turnstile_import_map = (
+    var.existing_turnstile_widget_id != null && length(var.turnstile_allowed_domains) > 0
+  ) ? { existing = var.existing_turnstile_widget_id } : {}
+}
+
+import {
+  for_each = local.d1_import_map
+  to       = module.cf_app_resources.cloudflare_d1_database.app
+  id       = each.value
+}
+
+import {
+  for_each = var.existing_kv_namespace_ids
+  to       = module.cf_app_resources.cloudflare_workers_kv_namespace.kv[each.key]
+  id       = each.value
+}
+
+import {
+  for_each = local.turnstile_import_map
+  to       = module.cf_app_resources.cloudflare_turnstile_widget.auth[0]
+  id       = each.value
+}

--- a/infra/terraform/envs/dev/databases/variables.tf
+++ b/infra/terraform/envs/dev/databases/variables.tf
@@ -39,3 +39,21 @@ variable "turnstile_region" {
   type        = string
   default     = "world"
 }
+
+variable "existing_d1_database_id" {
+  description = "既存の D1 データベースを取り込む場合の ID"
+  type        = string
+  default     = null
+}
+
+variable "existing_kv_namespace_ids" {
+  description = "既存の Workers KV Namespace を取り込む場合の ID マップ"
+  type        = map(string)
+  default     = {}
+}
+
+variable "existing_turnstile_widget_id" {
+  description = "既存の Turnstile ウィジェットを取り込む場合の ID"
+  type        = string
+  default     = null
+}

--- a/infra/terraform/envs/prod/databases/README.md
+++ b/infra/terraform/envs/prod/databases/README.md
@@ -25,7 +25,20 @@ turnstile_allowed_domains    = [
 turnstile_widget_mode        = "managed"
 turnstile_bot_fight_mode     = false
 turnstile_region             = "world"
+existing_d1_database_id      = null  # 既存リソースを取り込む場合は ID を設定
+existing_kv_namespace_ids    = {}    # { free_trial = "<namespace_id>" など }
+existing_turnstile_widget_id = null  # 既存 Turnstile を取り込む場合に設定
 ```
+
+## 既存リソースの取り込み
+
+Cloudflare 上に同名のリソースが既に存在する場合は、上記の `existing_*` 変数に ID を設定すると、`terraform apply` 実行時に import ブロックを通じて自動的に状態へ取り込まれます。
+
+- D1 データベース: `existing_d1_database_id = "<account_id>/<database_id>"`
+- Workers KV: `existing_kv_namespace_ids = { free_trial = "<account_id>/<namespace_id>", ... }`
+- Turnstile: `existing_turnstile_widget_id = "<account_id>/<widget_id>"`
+
+ID は `terraform state` や Cloudflare ダッシュボード／API から確認してください。値を設定しない場合は通常通り新規作成されます。
 
 ## 実行
 

--- a/infra/terraform/envs/prod/databases/import.tf
+++ b/infra/terraform/envs/prod/databases/import.tf
@@ -1,0 +1,25 @@
+locals {
+  d1_import_map = var.existing_d1_database_id == null ? {} : { existing = var.existing_d1_database_id }
+  # existing_kv_namespace_ids のキーは modules/cf-app-resources 内の local.kv_namespaces のキー（free_trial など）と一致させる
+  turnstile_import_map = (
+    var.existing_turnstile_widget_id != null && length(var.turnstile_allowed_domains) > 0
+  ) ? { existing = var.existing_turnstile_widget_id } : {}
+}
+
+import {
+  for_each = local.d1_import_map
+  to       = module.cf_app_resources.cloudflare_d1_database.app
+  id       = each.value
+}
+
+import {
+  for_each = var.existing_kv_namespace_ids
+  to       = module.cf_app_resources.cloudflare_workers_kv_namespace.kv[each.key]
+  id       = each.value
+}
+
+import {
+  for_each = local.turnstile_import_map
+  to       = module.cf_app_resources.cloudflare_turnstile_widget.auth[0]
+  id       = each.value
+}

--- a/infra/terraform/envs/prod/databases/variables.tf
+++ b/infra/terraform/envs/prod/databases/variables.tf
@@ -42,3 +42,21 @@ variable "turnstile_region" {
   type        = string
   default     = "world"
 }
+
+variable "existing_d1_database_id" {
+  description = "既存の D1 データベースを取り込む場合の ID"
+  type        = string
+  default     = null
+}
+
+variable "existing_kv_namespace_ids" {
+  description = "既存の Workers KV Namespace を取り込む場合の ID マップ"
+  type        = map(string)
+  default     = {}
+}
+
+variable "existing_turnstile_widget_id" {
+  description = "既存の Turnstile ウィジェットを取り込む場合の ID"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION

## 📒 変更の概要

- `check_for_changes_in_terraform_files.sh` スクリプトの修正により、Terraformファイルの差分検出が改善されました。
- 既存のD1データベース、Workers KV、Turnstileウィジェットを取り込むための変数が追加されました。
- 各環境のREADMEファイルに、既存リソースを取り込む方法に関する説明が追加されました。

## ⚒ 技術的詳細

- `check_for_changes_in_terraform_files.sh` スクリプトに以下の変更が加えられました:
  - 新しい関数 `normalize_path` が追加され、パスの正規化が行われるようになりました。
  - 変更されたファイルがデプロイパイプラインに関連するかどうかをチェックするロジックが改善されました。
  
- `import.tf` ファイルが新たに作成され、以下のリソースを取り込むための設定が追加されました:
  - D1データベース
  - Workers KV Namespace
  - Turnstileウィジェット

- 各環境の `variables.tf` に以下の変数が追加されました:
  - `existing_d1_database_id`
  - `existing_kv_namespace_ids`
  - `existing_turnstile_widget_id`

## ⚠ 注意点

> [!IMPORTANT]
> 
> - 既存リソースを取り込む場合は、適切なIDを設定する必要があります。設定しない場合は新規作成されますので注意してください。