### PR TITLE
🚀 cloudflare_d1_databaseリソースにread_replication設定を追加

### DIFF
--- a/infra/terraform/modules/cf-app-resources/main.tf
+++ b/infra/terraform/modules/cf-app-resources/main.tf
@@ -28,6 +28,9 @@ locals {
 resource "cloudflare_d1_database" "app" {
   account_id = var.cloudflare_account_id
   name       = local.d1_name
+  read_replication = {
+    mode = "disabled"
+  }
 }
 
 resource "cloudflare_workers_kv_namespace" "kv" {


### PR DESCRIPTION

このプルリクエストでは、`cloudflare_d1_database`リソースに`read_replication`設定を追加しました。

## 📒 変更の概要

- ✨ `cloudflare_d1_database`リソースに`read_replication`設定を追加しました。
- 🔧 `read_replication`の`mode`を`disabled`に設定しました。

## ⚒ 技術的詳細

- 📂 変更されたファイル: `infra/terraform/modules/cf-app-resources/main.tf`
- 🛠 `cloudflare_d1_database`リソースの定義に`read_replication`ブロックを追加し、`mode`を`disabled`に設定しました。これにより、データベースの読み取りレプリケーションが無効になります。

## ⚠ 注意点

- ⚠️ この変更は、データベースの読み取りレプリケーションを無効にするため、パフォーマンスに影響を与える可能性があります。運用環境での影響を考慮してください。