### PR TITLE
🚀 リリースワークフローの追加とドキュメントの整備

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,140 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'バージョンアップの種類'
+        required: true
+        type: choice
+        default: 'patch'
+        options:
+          - major
+          - minor
+          - patch
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: get-latest-tag
+        run: |
+          # 最新のタグを取得（SemVer形式のみ）
+          LATEST_TAG="$(git tag -l 'v*.*.*' --sort=-v:refname | head -n 1)"
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No previous tag found, using v0.0.0 as base"
+            LATEST_TAG="v0.0.0"
+          else
+            echo "Latest tag: $LATEST_TAG"
+          fi
+
+          echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate next version
+        id: calc-version
+        run: |
+          LATEST_TAG="${{ steps.get-latest-tag.outputs.latest_tag }}"
+          VERSION_BUMP="${{ inputs.version_bump }}"
+
+          # v プレフィックスを削除
+          VERSION=${LATEST_TAG#v}
+
+          # バージョン番号を分解
+          IFS='.' read -r -a VERSION_PARTS <<< "$VERSION"
+          MAJOR=${VERSION_PARTS[0]}
+          MINOR=${VERSION_PARTS[1]}
+          PATCH=${VERSION_PARTS[2]}
+
+          # バージョンをインクリメント
+          case "$VERSION_BUMP" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "New version: $NEW_VERSION"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        id: release-notes
+        run: |
+          LATEST_TAG="${{ steps.get-latest-tag.outputs.latest_tag }}"
+          NEW_VERSION="${{ steps.calc-version.outputs.new_version }}"
+
+          # リリースノートを生成
+          if [ "$LATEST_TAG" = "v0.0.0" ]; then
+            # 初回リリース: 全コミット履歴を取得
+            echo "Generating release notes from all commits..."
+            RELEASE_NOTES="$(git log --pretty=format:"- %s (%h)" --reverse)"
+          else
+            # 前回のタグからの差分を取得
+            echo "Generating release notes from $LATEST_TAG to HEAD..."
+            RELEASE_NOTES="$(git log "${LATEST_TAG}..HEAD" --pretty=format:"- %s (%h)" --reverse)"
+          fi
+
+          # リリースノートが空の場合
+          if [ -z "$RELEASE_NOTES" ]; then
+            RELEASE_NOTES="No changes since last release"
+          fi
+
+          # リリースノートをファイルに保存（複数行対応）
+          cat << EOF > release_notes.txt
+          ## What's Changed
+
+          $RELEASE_NOTES
+
+          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${LATEST_TAG}...${NEW_VERSION}
+          EOF
+
+          # デバッグ用
+          echo "Release notes:"
+          cat release_notes.txt
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_VERSION="${{ steps.calc-version.outputs.new_version }}"
+
+          # リリースを作成
+          gh release create "$NEW_VERSION" \
+            --title "$NEW_VERSION" \
+            --notes-file release_notes.txt \
+            --target main
+
+          echo "✅ Release $NEW_VERSION created successfully!"
+
+      - name: Summary
+        run: |
+          LATEST_TAG="${{ steps.get-latest-tag.outputs.latest_tag }}"
+          NEW_VERSION="${{ steps.calc-version.outputs.new_version }}"
+
+          cat << EOF >> "$GITHUB_STEP_SUMMARY"
+          ## 🎉 Release Created
+
+          - **Previous Version**: $LATEST_TAG
+          - **New Version**: $NEW_VERSION
+          - **Version Bump**: ${{ inputs.version_bump }}
+          - **Release URL**: https://github.com/${{ github.repository }}/releases/tag/$NEW_VERSION
+          EOF

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,0 +1,82 @@
+# リリースワークフロー
+
+このドキュメントでは、MathQuest プロジェクトのリリースワークフローについて説明します。
+
+## 概要
+
+MathQuest では、以下の 2 つのワークフローを使用してリリースを管理しています：
+
+1. **Create Release** (`.github/workflows/create-release.yml`): GitHub Release を作成する
+2. **Terraform - prod** (`.github/workflows/terraform-prod.yml`): GitHub Release をトリガーに本番環境へデプロイする
+
+## リリースの作成手順
+
+### 1. Create Release ワークフローを実行
+
+GitHub Actions の UI から手動で実行します：
+
+1. GitHub リポジトリの **Actions** タブを開く
+2. 左側のワークフロー一覧から **Create Release** を選択
+3. **Run workflow** ボタンをクリック
+4. バージョンアップの種類を選択:
+   - **major**: メジャーバージョンアップ（例: v1.0.0 → v2.0.0）
+   - **minor**: マイナーバージョンアップ（例: v1.0.0 → v1.1.0）
+   - **patch**: パッチバージョンアップ（例: v1.0.0 → v1.0.1）
+5. **Run workflow** ボタンをクリックして実行
+
+### 2. ワークフローの動作
+
+Create Release ワークフローは以下の処理を自動的に実行します：
+
+1. **最新タグの取得**: 既存の SemVer 形式のタグ（`v*.*.*`）から最新バージョンを取得
+   - タグが存在しない場合は `v0.0.0` を初期値として使用
+2. **次バージョンの計算**: 選択したバージョンアップの種類に基づいて新しいバージョンを計算
+3. **リリースノートの生成**:
+   - 初回リリース: 全コミット履歴を含める
+   - 2 回目以降: 前回のタグからの差分のみ含める
+4. **GitHub Release の作成**: 計算されたバージョンとリリースノートで GitHub Release を作成
+
+### 3. 本番環境へのデプロイ
+
+GitHub Release が作成されると、**Terraform - prod** ワークフローが自動的にトリガーされます：
+
+1. SemVer 形式のバリデーション
+2. Terraform の差分確認（plan）
+3. 差分がある場合、本番環境へ自動デプロイ（apply）
+
+## バージョニング規則
+
+このプロジェクトでは [Semantic Versioning 2.0.0](https://semver.org/) に従います：
+
+- **MAJOR**: 互換性のない API の変更
+- **MINOR**: 後方互換性のある機能の追加
+- **PATCH**: 後方互換性のあるバグ修正
+
+### バージョン形式
+
+- 形式: `vMAJOR.MINOR.PATCH`
+- 例: `v1.2.3`
+- プレリリース版: `v1.2.3-alpha.1`（現在は未サポート）
+
+## トラブルシューティング
+
+### タグが正しく作成されない
+
+- ワークフローログを確認して、エラーメッセージを確認してください
+- GitHub の権限設定で `contents: write` が許可されていることを確認してください
+
+### リリースノートが空
+
+- 前回のリリースから変更がない場合、"No changes since last release" と表示されます
+- 新しいコミットを追加してから再度ワークフローを実行してください
+
+### Terraform デプロイが失敗する
+
+- **Terraform - prod** ワークフローのログを確認してください
+- インフラストラクチャの設定や、必要な Secrets が正しく設定されているか確認してください
+- 詳細は `docs/github-secrets-setup.md` を参照してください
+
+## 関連ドキュメント
+
+- [GitHub Secrets セットアップ](./github-secrets-setup.md)
+- [ローカル開発環境](./local-dev.md)


### PR DESCRIPTION

このプルリクエストでは、MathQuestプロジェクトにリリースワークフローを追加し、リリース手順とバージョニング規則を文書化しました。

## 📒 変更の概要

1. ✨ `create-release.yml` ファイルを新規作成し、GitHub Releaseを作成するためのワークフローを追加しました。
2. 📄 `release-workflow.md` ドキュメントを新規作成し、リリースワークフローの手順とバージョニング規則を説明しました。

## ⚒ 技術的詳細

1. 🛠 `create-release.yml` では、以下のステップを実行します：
   - 最新のタグを取得し、存在しない場合は `v0.0.0` を初期値として使用します。
   - バージョンアップの種類（major, minor, patch）に基づいて新しいバージョンを計算します。
   - リリースノートを生成し、GitHub Releaseを作成します。
   
2. 📚 `release-workflow.md` では、リリースの作成手順やバージョニング規則について詳しく説明しています。

## ⚠ 注意点

1. ⚠️ ワークフローを実行する際は、GitHubの権限設定で `contents: write` が許可されていることを確認してください。
2. ⚠️ リリースノートが空の場合、前回のリリースから変更がないことを意味します。新しいコミットを追加してから再度ワークフローを実行してください。