### PR TITLE
🚀 Terraform - prodワークフローのトリガー条件をリリースイベントからプッシュイベントに変更

### DIFF
--- a/.github/workflows/terraform-prod.yml
+++ b/.github/workflows/terraform-prod.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
     branches:
       - main
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       CHECK_DIFF:
@@ -31,11 +32,12 @@ jobs:
   validate-semver:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name == 'release'
+    if: github.event_name == 'push'
     steps:
       - name: Validate SemVer tag
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${{ github.ref_name }}"
+
           if [[ ! "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$ ]]; then
             echo "Error: Tag '$TAG' is not a valid SemVer format"
             echo "Expected format: v1.2.3 or 1.2.3 (with optional pre-release and build metadata)"
@@ -103,7 +105,7 @@ jobs:
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Start Deployment
-        if: env.TF_PLAN_STATUS == 'has-diff' && github.event_name == 'release'
+        if: env.TF_PLAN_STATUS == 'has-diff' && github.event_name == 'push'
         uses: bobheadxi/deployments@v1
         id: deployment
         with:
@@ -112,7 +114,7 @@ jobs:
           env: ${{ env.AWS_ENV_NAME }}
 
       - name: Terraform Apply
-        if: env.TF_PLAN_STATUS == 'has-diff' && github.event_name == 'release'
+        if: env.TF_PLAN_STATUS == 'has-diff' && github.event_name == 'push'
         uses: ./.github/actions/terraform-apply
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -134,7 +136,7 @@ jobs:
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Finish Deployment
-        if: env.TF_PLAN_STATUS == 'has-diff' && always() && github.event_name == 'release'
+        if: env.TF_PLAN_STATUS == 'has-diff' && always() && github.event_name == 'push'
         uses: bobheadxi/deployments@v1
         with:
           step: finish

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -38,11 +38,17 @@ Create Release ワークフローは以下の処理を自動的に実行しま�
 
 ### 3. 本番環境へのデプロイ
 
-GitHub Release が作成されると、**Terraform - prod** ワークフローが自動的にトリガーされます：
+GitHub Release が作成されると、タグがプッシュされ、**Terraform - prod** ワークフローが自動的にトリガーされます：
 
 1. SemVer 形式のバリデーション
 2. Terraform の差分確認（plan）
 3. 差分がある場合、本番環境へ自動デプロイ（apply）
+
+**注**: `terraform-prod.yml` は以下のイベントでトリガーされます:
+
+- `push: tags: v*.*.*` - SemVer 形式のタグがプッシュされたとき（デプロイ実行）
+- `pull_request: branches: main` - main ブランチへの PR（plan のみ）
+- `workflow_dispatch` - 手動実行
 
 ## バージョニング規則
 


### PR DESCRIPTION

## 📒 変更の概要

- `terraform-prod.yml` のトリガー条件を更新し、リリースイベントからタグのプッシュイベントに変更しました。
- これにより、GitHub Release が作成されると、タグがプッシュされることで **Terraform - prod** ワークフローが自動的にトリガーされるようになります。

## ⚒ 技術的詳細

- `terraform-prod.yml` の以下の変更が行われました：
  - `release` イベントのトリガーを削除し、代わりに `push` イベントを追加しました。
  - SemVer 形式のタグがプッシュされたときにワークフローが実行されるように設定しました。
  - デプロイメントの条件も `release` から `push` に変更されました。

- `release-workflow.md` のドキュメントも更新され、ワークフローのトリガー条件が明確に説明されています。

## ⚠ 注意点

- 💡 新しいトリガー条件により、リリースイベントではなく、タグのプッシュによってデプロイが行われるため、運用フローに影響を与える可能性があります。適切なタグ付けを行うことが重要です。