### PR TITLE
🚀 Terraform - prodワークフローをrepository_dispatchイベントでトリガーする変更

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -125,6 +125,19 @@ jobs:
 
           echo "✅ Release $NEW_VERSION created successfully!"
 
+      - name: Trigger Terraform Deploy
+        run: |
+          NEW_VERSION="${{ steps.calc-version.outputs.new_version }}"
+
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/dispatches" \
+            -d "{\"event_type\":\"release-created\",\"client_payload\":{\"tag\":\"$NEW_VERSION\"}}"
+
+          echo "✅ Triggered terraform-prod workflow for $NEW_VERSION"
+
       - name: Summary
         run: |
           LATEST_TAG="${{ steps.get-latest-tag.outputs.latest_tag }}"

--- a/.github/workflows/terraform-prod.yml
+++ b/.github/workflows/terraform-prod.yml
@@ -7,6 +7,8 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  repository_dispatch:
+    types: [release-created]
   workflow_dispatch:
     inputs:
       CHECK_DIFF:
@@ -32,11 +34,15 @@ jobs:
   validate-semver:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
     steps:
       - name: Validate SemVer tag
         run: |
-          TAG="${{ github.ref_name }}"
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            TAG="${{ github.event.client_payload.tag }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
 
           if [[ ! "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$ ]]; then
             echo "Error: Tag '$TAG' is not a valid SemVer format"
@@ -105,7 +111,7 @@ jobs:
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Start Deployment
-        if: env.TF_PLAN_STATUS == 'has-diff' && github.event_name == 'push'
+        if: env.TF_PLAN_STATUS == 'has-diff' && (github.event_name == 'push' || github.event_name == 'repository_dispatch')
         uses: bobheadxi/deployments@v1
         id: deployment
         with:
@@ -114,7 +120,7 @@ jobs:
           env: ${{ env.AWS_ENV_NAME }}
 
       - name: Terraform Apply
-        if: env.TF_PLAN_STATUS == 'has-diff' && github.event_name == 'push'
+        if: env.TF_PLAN_STATUS == 'has-diff' && (github.event_name == 'push' || github.event_name == 'repository_dispatch')
         uses: ./.github/actions/terraform-apply
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -136,7 +142,7 @@ jobs:
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Finish Deployment
-        if: env.TF_PLAN_STATUS == 'has-diff' && always() && github.event_name == 'push'
+        if: env.TF_PLAN_STATUS == 'has-diff' && always() && (github.event_name == 'push' || github.event_name == 'repository_dispatch')
         uses: bobheadxi/deployments@v1
         with:
           step: finish

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -38,7 +38,7 @@ Create Release ワークフローは以下の処理を自動的に実行しま�
 
 ### 3. 本番環境へのデプロイ
 
-GitHub Release が作成されると、タグがプッシュされ、**Terraform - prod** ワークフローが自動的にトリガーされます：
+GitHub Release が作成されると、`repository_dispatch` イベントを使用して **Terraform - prod** ワークフローが自動的にトリガーされます：
 
 1. SemVer 形式のバリデーション
 2. Terraform の差分確認（plan）
@@ -46,9 +46,12 @@ GitHub Release が作成されると、タグがプッシュされ、**Terraform
 
 **注**: `terraform-prod.yml` は以下のイベントでトリガーされます:
 
-- `push: tags: v*.*.*` - SemVer 形式のタグがプッシュされたとき（デプロイ実行）
+- `push: tags: v*.*.*` - SemVer 形式のタグが直接プッシュされたとき（デプロイ実行）
+- `repository_dispatch: types: [release-created]` - `create-release.yml` からのトリガー（デプロイ実行）
 - `pull_request: branches: main` - main ブランチへの PR（plan のみ）
 - `workflow_dispatch` - 手動実行
+
+**重要**: GitHub Actions の `GITHUB_TOKEN` で作成されたタグは、他のワークフローをトリガーしないため、`create-release.yml` は `repository_dispatch` イベントを使用して明示的に `terraform-prod.yml` をトリガーします。
 
 ## バージョニング規則
 


### PR DESCRIPTION

## 📒 変更の概要

- `create-release.yml`に、GitHub Release作成時に`repository_dispatch`イベントを使用して**Terraform - prod**ワークフローをトリガーする機能を追加しました。
- `terraform-prod.yml`は、`repository_dispatch`イベントを受け取るように設定され、リリース作成時にデプロイメントを実行します。

## ⚒ 技術的詳細

- `create-release.yml`に以下のステップを追加しました:
  - GitHub APIを使用して`repository_dispatch`イベントをトリガーし、リリースのバージョンをペイロードとして送信します。
  
- `terraform-prod.yml`では、以下の変更を行いました:
  - `repository_dispatch`イベントを受け取るように設定し、リリース作成時にデプロイメントを実行します。
  - SemVerタグのバリデーションを行う条件に`repository_dispatch`を追加しました。
  - デプロイメントの開始、適用、終了の条件に`repository_dispatch`を追加しました。

## ⚠ 注意点

> [!IMPORTANT]
> 
> - GitHub Actionsの`GITHUB_TOKEN`で作成されたタグは、他のワークフローをトリガーしないため、`create-release.yml`は`repository_dispatch`イベントを使用して明示的に`terraform-prod.yml`をトリガーします。