### PR TITLE
Update Slack deploy failure notifications

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,3 +26,20 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           resendApiKey: ${{ secrets.RESEND_API_KEY_DEV }}
+
+      - name: Slack Notification (failure)
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: '#edu-quest-dev'
+          SLACK_COLOR: danger
+          SLACK_TITLE: 'Deploy to Dev failed'
+          SLACK_MESSAGE: |
+            Dev環境へのデプロイが失敗しました。ログを確認して対応をお願いします。
+            workflow: ${{ github.workflow }}
+            job: ${{ github.job }}
+            run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_LINK_NAMES: 'true'
+          SLACK_USERNAME: github-bot
+          SLACK_ICON_EMOJI: ':x:'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -22,3 +22,20 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           resendApiKey: ${{ secrets.RESEND_API_KEY_PROD }}
+
+      - name: Slack Notification (failure)
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: '#edu-quest-prod'
+          SLACK_COLOR: danger
+          SLACK_TITLE: 'Deploy to Production failed'
+          SLACK_MESSAGE: |
+            本番環境へのデプロイが失敗しました。ログを確認して対応をお願いします。
+            workflow: ${{ github.workflow }}
+            job: ${{ github.job }}
+            run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_LINK_NAMES: 'true'
+          SLACK_USERNAME: github-bot
+          SLACK_ICON_EMOJI: ':x:'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_PROD }}


### PR DESCRIPTION
## Summary
- update Slack failure notifications in dev and production workflows
- adjust channel targets and remove the explicit subteam mention
- improve the failure messages for better guidance

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68f929c12eac8321acffaba46256feb3