### PR TITLE
🐛 tfcmtのラベル追加を修正

### DIFF
--- a/.github/tfcmt.yml
+++ b/.github/tfcmt.yml
@@ -47,6 +47,7 @@ ci:
     - when_plan_no_diff:
         color: '#28a745'
         skip_add_label: true
+        label: ''
         template: |
           ## Terraform `{{ .Command }}` ({{ .Vars.target }})
 


### PR DESCRIPTION

## 📒 変更の概要

- `tfcmt.yml`ファイルにおいて、Terraformプランに変更がない場合にラベルを追加しないように修正しました。

## ⚒ 技術的詳細

- `tfcmt.yml`の`when_plan_no_diff`セクションに`skip_add_label: true`を追加し、変更がない場合にラベルが追加されないように設定しました。
- さらに、`label: ''`を追加することで、ラベルの値を空に設定しました。

## ⚠ 注意点

> [!WARNING]
>
> - 💣 この変更は、Terraformプランに変更がない場合にラベルが追加されないことを意味します。動作を確認する際は、プランに変更がない状態でテストを行ってください。