### PR TITLE
✨ EduQuestのファビコンを更新する

### DIFF
--- a/apps/edge/src/views/layouts/document.tsx
+++ b/apps/edge/src/views/layouts/document.tsx
@@ -21,9 +21,9 @@ export const Document: FC<DocumentProps> = ({
   const year = new Date().getFullYear();
   const isDev = environment === 'dev';
 
-  // Default MathQuest favicon
+  // Default EduQuest favicon
   const defaultFavicon =
-    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='18' fill='%2378c2c3'/%3E%3Ctext x='50%25' y='54%25' text-anchor='middle' fill='%231f2a4a' font-family='Zen Kaku Gothic New, sans-serif' font-size='28' font-weight='700'%3EMQ%3C/text%3E%3C/svg%3E";
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='18' fill='%231f2a4a'/%3E%3Ctext x='50%25' y='55%25' text-anchor='middle' fill='%23ffffff' font-family='Zen Kaku Gothic New, sans-serif' font-size='28' font-weight='700'%3EEQ%3C/text%3E%3C/svg%3E";
 
   return html`
     <!doctype html>


### PR DESCRIPTION

## Pull Request Description

### 📒 変更の概要

- デフォルトのファビコンを「MathQuest」から「EduQuest」に変更しました。

### ⚒ 技術的詳細

- `apps/edge/src/views/layouts/document.tsx`ファイル内のファビコンのSVGデータを更新しました。
- 新しいファビコンは、背景色がダークブルーで、テキストが白色の「EQ」となっています。

### ⚠ 注意点

> [!WARNING]
>
> - 💣 この変更は、ファビコンの見た目に影響を与えます。適切に表示されることを確認してください。