### PR TITLE
Add bilingual cross-links to documentation

### DIFF
--- a/.rulesync/rules/agents.md
+++ b/.rulesync/rules/agents.md
@@ -1,4 +1,4 @@
-[日本語](/docs/AGENTS.ja.md)
+[🇯🇵 日本語](/docs/AGENTS.ja.md)
 
 ## 1. Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-[日本語](/docs/CLAUDE.ja.md)
+[🇯🇵 日本語](/docs/CLAUDE.ja.md)
 
 # Claude Project Instructions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-[日本語](/docs/CONTRIBUTING.ja.md)
+[🇯🇵 日本語](/docs/CONTRIBUTING.ja.md)
 
 # Contributing to EduQuest
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[日本語](/docs/README.ja.md)
+[🇯🇵 日本語](/docs/README.ja.md)
 
 # EduQuest Document Overview
 

--- a/docs/AGENTS.ja.md
+++ b/docs/AGENTS.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/AGENTS.md)
+[🇺🇸 English](/docs/AGENTS.md)
 
 # AGENTS.md
 

--- a/docs/AI_RULES.ja.md
+++ b/docs/AI_RULES.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/AI_RULES.md)
+[🇺🇸 English](/docs/AI_RULES.md)
 
 # AI アシスタント共通ルール（日本語）
 

--- a/docs/AI_RULES.md
+++ b/docs/AI_RULES.md
@@ -1,4 +1,4 @@
-[日本語](/docs/AI_RULES.ja.md)
+[🇯🇵 日本語](/docs/AI_RULES.ja.md)
 
 # Common Rules for AI Assistants (English)
 

--- a/docs/CLAUDE.ja.md
+++ b/docs/CLAUDE.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/CLAUDE.md)
+[🇺🇸 English](/docs/CLAUDE.md)
 
 # CLAUDE.md
 

--- a/docs/CONTRIBUTING.ja.md
+++ b/docs/CONTRIBUTING.ja.md
@@ -1,4 +1,4 @@
-[English](/CONTRIBUTING.md)
+[🇺🇸 English](/CONTRIBUTING.md)
 
 # EduQuest へのコントリビューション
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/README.md)
+[🇺🇸 English](/docs/README.md)
 
 # EduQuest ドキュメント概要
 

--- a/docs/RULESYNC.ja.md
+++ b/docs/RULESYNC.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/RULESYNC.md)
+[🇺🇸 English](/docs/RULESYNC.md)
 
 # rulesync 導入ガイド
 

--- a/docs/RULESYNC.md
+++ b/docs/RULESYNC.md
@@ -1,4 +1,4 @@
-[日本語](/docs/RULESYNC.ja.md)
+[🇯🇵 日本語](/docs/RULESYNC.ja.md)
 
 # rulesync Implementation Guide
 

--- a/docs/edu-quest-architecture.ja.md
+++ b/docs/edu-quest-architecture.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/edu-quest-architecture.md)
+[🇺🇸 English](/docs/edu-quest-architecture.md)
 
 # eduquest: アーキテクチャ設計とプロジェクト構造
 

--- a/docs/edu-quest-architecture.md
+++ b/docs/edu-quest-architecture.md
@@ -1,4 +1,4 @@
-[日本語](/docs/edu-quest-architecture.ja.md)
+[🇯🇵 日本語](/docs/edu-quest-architecture.ja.md)
 
 # eduquest: Architecture Design and Project Structure
 

--- a/docs/edu-quest-migration.ja.md
+++ b/docs/edu-quest-migration.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/edu-quest-migration.md)
+[🇺🇸 English](/docs/edu-quest-migration.md)
 
 # EduQuest 移行計画
 

--- a/docs/edu-quest-migration.md
+++ b/docs/edu-quest-migration.md
@@ -1,4 +1,4 @@
-[日本語](/docs/edu-quest-migration.ja.md)
+[🇯🇵 日本語](/docs/edu-quest-migration.ja.md)
 
 # EduQuest Migration Plan
 

--- a/docs/edu-quest-wireframe.ja.md
+++ b/docs/edu-quest-wireframe.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/edu-quest-wireframe.md)
+[🇺🇸 English](/docs/edu-quest-wireframe.md)
 
 # eduquest: ワイヤーフレーム
 

--- a/docs/edu-quest-wireframe.md
+++ b/docs/edu-quest-wireframe.md
@@ -1,4 +1,4 @@
-[日本語](/docs/edu-quest-wireframe.ja.md)
+[🇯🇵 日本語](/docs/edu-quest-wireframe.ja.md)
 
 # eduquest: Wireframes
 

--- a/docs/gemini-instructions.ja.md
+++ b/docs/gemini-instructions.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/gemini-instructions.md)
+[🇺🇸 English](/docs/gemini-instructions.md)
 
 # Gemini Code Assist 用メモ
 

--- a/docs/gemini-instructions.md
+++ b/docs/gemini-instructions.md
@@ -1,4 +1,4 @@
-[日本語](/docs/gemini-instructions.ja.md)
+[🇯🇵 日本語](/docs/gemini-instructions.ja.md)
 
 # Notes for Gemini Code Assist
 

--- a/docs/github-secrets-setup.ja.md
+++ b/docs/github-secrets-setup.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/github-secrets-setup.md)
+[🇺🇸 English](/docs/github-secrets-setup.md)
 
 # GitHub Secrets セットアップガイド
 

--- a/docs/github-secrets-setup.md
+++ b/docs/github-secrets-setup.md
@@ -1,4 +1,4 @@
-[日本語](/docs/github-secrets-setup.ja.md)
+[🇯🇵 日本語](/docs/github-secrets-setup.ja.md)
 
 # GitHub Secrets Setup Guide
 

--- a/docs/hono-ddd-monorepo.ja.md
+++ b/docs/hono-ddd-monorepo.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/hono-ddd-monorepo.md)
+[🇺🇸 English](/docs/hono-ddd-monorepo.md)
 
 # Hono × DDD モノレポ構成（最小）
 

--- a/docs/hono-ddd-monorepo.md
+++ b/docs/hono-ddd-monorepo.md
@@ -1,4 +1,4 @@
-[日本語](/docs/hono-ddd-monorepo.ja.md)
+[🇯🇵 日本語](/docs/hono-ddd-monorepo.ja.md)
 
 # Minimal Hono × DDD Monorepo Structure
 

--- a/docs/kanji-quest-design.ja.md
+++ b/docs/kanji-quest-design.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/kanji-quest-design.md)
+[🇺🇸 English](/docs/kanji-quest-design.md)
 
 # KanjiQuest 設計ドキュメント
 

--- a/docs/kanji-quest-design.md
+++ b/docs/kanji-quest-design.md
@@ -1,4 +1,4 @@
-[日本語](/docs/kanji-quest-design.ja.md)
+[🇯🇵 日本語](/docs/kanji-quest-design.ja.md)
 
 # KanjiQuest Design Document
 

--- a/docs/local-dev.ja.md
+++ b/docs/local-dev.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/local-dev.md)
+[🇺🇸 English](/docs/local-dev.md)
 
 # ローカル検証環境の作り方
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,4 +1,4 @@
-[日本語](/docs/local-dev.ja.md)
+[🇯🇵 日本語](/docs/local-dev.ja.md)
 
 # Local Development Environments
 

--- a/docs/math-quiz.ja.md
+++ b/docs/math-quiz.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/math-quiz.md)
+[🇺🇸 English](/docs/math-quiz.md)
 
 # 算数クイズ（小学生向け）
 

--- a/docs/math-quiz.md
+++ b/docs/math-quiz.md
@@ -1,4 +1,4 @@
-[日本語](/docs/math-quiz.ja.md)
+[🇯🇵 日本語](/docs/math-quiz.ja.md)
 
 # Math Quiz (Elementary School)
 

--- a/docs/release-workflow.ja.md
+++ b/docs/release-workflow.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/release-workflow.md)
+[🇺🇸 English](/docs/release-workflow.md)
 
 # リリースワークフロー
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,4 +1,4 @@
-[日本語](/docs/release-workflow.ja.md)
+[🇯🇵 日本語](/docs/release-workflow.ja.md)
 
 # Release Workflow
 

--- a/docs/ux-design-concept.ja.md
+++ b/docs/ux-design-concept.ja.md
@@ -1,4 +1,4 @@
-[English](/docs/ux-design-concept.md)
+[🇺🇸 English](/docs/ux-design-concept.md)
 
 # eduquest: UI/UXデザインコンセプト
 

--- a/docs/ux-design-concept.md
+++ b/docs/ux-design-concept.md
@@ -1,4 +1,4 @@
-[日本語](/docs/ux-design-concept.ja.md)
+[🇯🇵 日本語](/docs/ux-design-concept.ja.md)
 
 # eduquest: UI/UX Design Concept
 


### PR DESCRIPTION
## Summary
- add language switch links to each English documentation page pointing to its Japanese counterpart
- add reciprocal links to the top of the Japanese documentation pages
- update the root guides and synced agents rule file to reference the localized documents

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_690272c353ec8321ac2aa2c2cd990854