### PR TITLE
🚀 KanjiQuestクイズに「やめる」オプションを追加

### DIFF
--- a/apps/edge/src/index.tsx
+++ b/apps/edge/src/index.tsx
@@ -329,6 +329,39 @@ app.get('/kanji/quiz', async (c) => {
   }
 });
 
+app.post('/kanji/quit', async (c) => {
+  const cookies = c.req.header('Cookie') ?? '';
+  const sessionMatch = cookies.match(/kanji_session_id=([^;]+)/);
+
+  if (sessionMatch) {
+    const sessionId = sessionMatch[1];
+
+    try {
+      await c.env.KV_QUIZ_SESSION.delete(`kanji:${sessionId}`);
+    } catch (error) {
+      console.error('Failed to delete kanji quiz session:', error);
+    }
+  }
+
+  const body = await c.req.parseBody();
+  const rawGrade = body.grade;
+  const grade = typeof rawGrade === 'string' ? Number(rawGrade) : NaN;
+  const isValidGrade = Number.isInteger(grade) && grade >= 1 && grade <= 6;
+  const redirectUrl = isValidGrade ? `/kanji/select?grade=${grade}` : '/kanji';
+
+  const response = c.redirect(redirectUrl, 302);
+  response.headers.append(
+    'Set-Cookie',
+    'kanji_session_id=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure'
+  );
+  response.headers.append(
+    'Set-Cookie',
+    'kanji_result_id=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure'
+  );
+
+  return response;
+});
+
 // KanjiQuest: 回答を送信
 app.post('/kanji/quiz', async (c) => {
   const cookies = c.req.header('Cookie') ?? '';

--- a/apps/edge/src/routes/pages/kanji-quiz.tsx
+++ b/apps/edge/src/routes/pages/kanji-quiz.tsx
@@ -34,13 +34,24 @@ export const KanjiQuiz: FC<KanjiQuizProps> = ({
             KanjiQuest {grade}年生
           </span>
         </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm font-semibold text-[var(--mq-ink)]">
-            問題 {questionNumber} / {totalQuestions}
-          </span>
-          <span class="text-sm font-semibold text-[var(--mq-primary-strong)]">
-            正解数: {score}
-          </span>
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+          <div class="flex items-center gap-4">
+            <span class="text-sm font-semibold text-[var(--mq-ink)]">
+              問題 {questionNumber} / {totalQuestions}
+            </span>
+            <span class="text-sm font-semibold text-[var(--mq-primary-strong)]">
+              正解数: {score}
+            </span>
+          </div>
+          <form method="POST" action="/kanji/quit" class="sm:ml-auto">
+            <input type="hidden" name="grade" value={grade} />
+            <button
+              type="submit"
+              class="w-full rounded-2xl border border-[var(--mq-outline)] bg-white px-4 py-2 text-sm font-semibold text-[var(--mq-ink)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--mq-primary-soft)] sm:w-auto"
+            >
+              やめる
+            </button>
+          </form>
         </div>
       </nav>
 


### PR DESCRIPTION

## 📒 変更の概要

- `apps/edge/src/index.tsx` に `/kanji/quit` エンドポイントを追加しました。このエンドポイントは、クイズセッションを削除し、指定された学年に基づいてリダイレクトします。
- `apps/edge/src/routes/pages/kanji-quiz.tsx` に「やめる」ボタンを追加し、ユーザーがクイズを終了できるようにしました。

## ⚒ 技術的詳細

- `/kanji/quit` エンドポイントでは、クッキーからセッションIDを取得し、関連するクイズセッションを削除します。
- ユーザーが送信した学年が有効な場合、`/kanji/select?grade={grade}` にリダイレクトし、無効な場合は `/kanji` にリダイレクトします。
- クッキーを削除するために、`Set-Cookie` ヘッダーを使用しています。

```mermaid
flowchart TD
    A[ユーザー] -->|やめるボタンをクリック| B[/kanji/quit]
    B --> C{セッションIDが存在するか}
    C -->|はい| D[セッションを削除]
    C -->|いいえ| E[何もしない]
    D --> F{学年が有効か}
    F -->|はい| G[/kanji/select?grade={grade}]
    F -->|いいえ| H[/kanji]
```

## ⚠ 注意点

- 💡 セッションが存在しない場合、何も削除されません。
- 🔒 クッキーの削除は、HTTPOnlyおよびSecure属性を持つため、クライアント側からはアクセスできません。