### PR TITLE
🛠️ Kanji選択ページのインポート修正

### DIFF
--- a/apps/edge/src/index.tsx
+++ b/apps/edge/src/index.tsx
@@ -15,6 +15,7 @@ import { ClockResults } from './routes/pages/clock-results';
 import { KanjiHome } from './routes/pages/kanji-home';
 import { KanjiQuiz } from './routes/pages/kanji-quiz';
 import { KanjiResults } from './routes/pages/kanji-results';
+import { KanjiSelect } from './routes/pages/kanji-select';
 import { MathHome } from './routes/pages/math-home';
 import { MathSelect } from './routes/pages/math-select';
 import { GameHome } from './routes/pages/game-home';
@@ -504,7 +505,6 @@ app.get('/kanji/select', async (c) => {
   }
 
   const grade = parsedGrade.grade as KanjiGrade;
-  const { KanjiSelect } = await import('./routes/pages/kanji-select');
   const gradeLabel = formatSchoolGradeLabel(parsedGrade);
 
   return c.render(


### PR DESCRIPTION

## Pull Request Description

### 📒 変更の概要

- `kanji-select`ページのインポートを修正しました。これにより、アプリケーション内でのKanji選択機能が正しく動作するようになります。

### ⚒ 技術的詳細

- `apps/edge/src/index.tsx`ファイルにおいて、`KanjiSelect`コンポーネントをインポートする行を追加しました。
- 不要な動的インポートを削除し、静的インポートに変更しました。これにより、パフォーマンスが向上し、コードの可読性が向上します。

### ⚠ 注意点

- 💡 この変更は、`kanji/select`エンドポイントに影響を与えます。エンドポイントが正しく機能することを確認するために、テストを実行してください。