### PR TITLE
リリースキャッシュタグのリセット機能を追加

### DIFF
--- a/apps/edge/src/index.tsx
+++ b/apps/edge/src/index.tsx
@@ -93,6 +93,32 @@ type GlobalWithProcess = typeof globalThis & {
   };
 };
 
+type GlobalWithReleaseCacheTag = GlobalWithProcess & {
+  __RELEASE_CACHE_TAG__?: string;
+};
+
+const getReleaseCacheTag = (): string => {
+  const globalWithTag = globalThis as GlobalWithReleaseCacheTag;
+
+  if (!globalWithTag.__RELEASE_CACHE_TAG__) {
+    const randomUUID = globalWithTag.crypto?.randomUUID?.bind(
+      globalWithTag.crypto
+    );
+
+    globalWithTag.__RELEASE_CACHE_TAG__ = randomUUID
+      ? randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  }
+
+  return globalWithTag.__RELEASE_CACHE_TAG__;
+};
+
+const createReleaseCacheKey = (): string => {
+  const url = new URL(GITHUB_RELEASE_ENDPOINT);
+  url.searchParams.set('deploy', getReleaseCacheTag());
+  return url.toString();
+};
+
 const fetchLatestRelease = async (): Promise<ReleaseInfo | null> => {
   try {
     const maybeProcess = (globalThis as GlobalWithProcess).process;
@@ -101,20 +127,20 @@ const fetchLatestRelease = async (): Promise<ReleaseInfo | null> => {
     }
 
     const cache = globalThis.caches?.default;
-    const createCacheRequest = () => new Request(GITHUB_RELEASE_ENDPOINT);
+    const cacheKey = createReleaseCacheKey();
 
     if (cache) {
-      const cached = await cache.match(createCacheRequest());
+      const cached = await cache.match(cacheKey);
       if (cached) {
         try {
           return (await cached.json()) as ReleaseInfo;
         } catch {
-          await cache.delete(createCacheRequest());
+          await cache.delete(cacheKey);
         }
       }
     }
 
-    const response = await fetch(GITHUB_RELEASE_ENDPOINT, {
+    const response = await fetch(cacheKey, {
       headers: {
         'User-Agent': 'edu-quest-worker',
         Accept: 'application/vnd.github+json',
@@ -143,7 +169,7 @@ const fetchLatestRelease = async (): Promise<ReleaseInfo | null> => {
           'Content-Type': 'application/json',
         },
       });
-      await cache.put(createCacheRequest(), cacheResponse);
+      await cache.put(cacheKey, cacheResponse);
     }
 
     return releaseInfo;


### PR DESCRIPTION

## 📒 変更の概要

- ✨ `GlobalWithReleaseCacheTag` 型を追加し、リリースキャッシュタグを管理するためのプロパティを定義しました。
- 🔄 `getReleaseCacheTag` 関数を追加し、リリースキャッシュタグを生成または取得するロジックを実装しました。
- 🔑 `createReleaseCacheKey` 関数を追加し、リリースキャッシュキーを生成するためのURLを作成する機能を追加しました。
- 📥 `fetchLatestRelease` 関数内で、キャッシュの取得および保存に新しいキャッシュキーを使用するように変更しました。

## ⚒ 技術的詳細

- `getReleaseCacheTag` 関数は、グローバルオブジェクトにリリースキャッシュタグが存在しない場合に新しいタグを生成します。UUIDを使用できない場合は、現在のタイムスタンプとランダムな数値を組み合わせてタグを生成します。
- `createReleaseCacheKey` 関数は、GitHubリリースエンドポイントにデプロイパラメータを追加したURLを生成します。
- `fetchLatestRelease` 関数では、キャッシュの取得と保存において新しく作成したキャッシュキーを使用するように変更されました。

## ⚠ 注意点

- ⚠️ この変更により、リリースキャッシュの管理が改善されますが、既存のキャッシュが新しいキーに基づいて更新されるため、キャッシュの整合性に注意が必要です。