### PR TITLE
📝 フッターの著作権情報を更新

### DIFF
--- a/apps/edge/src/components/Footer.tsx
+++ b/apps/edge/src/components/Footer.tsx
@@ -56,7 +56,7 @@ export const Footer: FC = () => (
 
       <div class="mt-16 mb-4">
         <p class="text-center text-xs text-[#5e718a]">
-          © 2025 EduQuest. All rights reserved.
+          © 2025 tqer39. All rights reserved.
         </p>
       </div>
     </div>


### PR DESCRIPTION

このプルリクエストでは、アプリケーションのフッターに表示される著作権情報を更新しました。

## 📒 変更の概要

- `Footer.tsx` ファイル内の著作権表示を「© 2025 EduQuest. All rights reserved.」から「© 2025 tqer39. All rights reserved.」に変更しました。

## ⚒ 技術的詳細

- 変更は `Footer.tsx` コンポーネント内で行われており、著作権情報が更新されています。この変更は、アプリケーションのフッター部分に直接影響を与えます。

## ⚠ 注意点

- 特に注意点はありませんが、フッターの著作権情報が正確であることを確認してください。